### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,10 +18,28 @@ before_action :authenticate_user!, except: [:index, :show]
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update(item_params)
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :price, :introduction, :category_id, :status_id, :trading_price_id, :trading_area_id, :trading_days_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :price, :introduction, :category_id, :status_id, :trading_price_id, :trading_area_id, :trading_day_id).merge(user_id: current_user.id)
   end
 end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
 before_action :authenticate_user!, except: [:index, :show]
+before_action :set_item, only: [:show ]
   
   def index
     @items = Item.all.order("created_at DESC")
@@ -19,22 +20,21 @@ before_action :authenticate_user!, except: [:index, :show]
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
-  def destroy
-    item = Item.find(params[:id])
-    item.destroy
-  end
+  #def destroy
+    #item = Item.find(params[:id])
+    #item.destroy
+  #end
 
-  def edit
-    @item = Item.find(params[:id])
-  end
+  #ef edit
+    #@item = Item.find(params[:id])
+  #end
 
-  def update
-    item = Item.find(params[:id])
-    item.update(item_params)
-  end
+  #def update
+    #item = Item.find(params[:id])
+    #item.update(item_params)
+  #end
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,5 +18,5 @@ class Item < ApplicationRecord
   validates :status_id, numericality: { other_than: 1 , message: "can't be blank"} 
   validates :trading_price_id, numericality: { other_than: 1 , message: "can't be blank"} 
   validates :trading_area_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :trading_days_id, numericality: { other_than: 1 , message: "can't be blank"}
+  validates :trading_day_id, numericality: { other_than: 1 , message: "can't be blank"}
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -81,7 +81,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:trading_days_id, TradingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:trading_day_id, TradingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -101,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,70 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <% if @items.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <%end%>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+      ¥<%= @item.price %> 
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.trading_price.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %> 
+        <%= link_to "編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
+      <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.trading_price.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.trading_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.trading_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,8 +24,6 @@
         <%= @item.trading_price.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %> 
         <%= link_to "編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
@@ -37,9 +35,6 @@
       <% end %>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <div class="item-explain-box">
       <span><%= @item.introduction %></span>
     </div>
@@ -107,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/db/migrate/20220806045239_create_items.rb
+++ b/db/migrate/20220806045239_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer    :status_id, null: false
       t.integer    :trading_price_id, null: false
       t.integer    :trading_area_id, null: false
-      t.integer    :trading_days_id, null: false
+      t.integer    :trading_day_id, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,12 +42,12 @@ ActiveRecord::Schema.define(version: 2022_08_08_053749) do
     t.string "name", null: false
     t.integer "price", null: false
     t.text "introduction", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.integer "category_id", null: false
     t.integer "status_id", null: false
     t.integer "trading_price_id", null: false
     t.integer "trading_area_id", null: false
-    t.integer "trading_days_id", null: false
+    t.integer "trading_day_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
@@ -92,4 +92,5 @@ ActiveRecord::Schema.define(version: 2022_08_08_053749) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "items", "users"
 end


### PR DESCRIPTION
What
ログイン状況に応じて画面の状況を変化させること
Why
状況に応じて商品詳細ページの表示を変えることができるようになることです

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7af7b676dfac860bb1e334fe4a125f69
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/0c86fc9cbae59605fe32d36c122b779a
ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/91136c578a952bbd95f05c88b4741463

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
現段階では未実装